### PR TITLE
Moved social links, author name, etc to consts file.

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -4,7 +4,7 @@
 import '../styles/global.css';
 import type { ImageMetadata } from 'astro';
 import FallbackImage from '../assets/images/blog-placeholder-1.jpg';
-import { SITE_TITLE } from '../consts';
+import { SITE_TITLE, TWITTER, LINKEDIN, HANDLE } from '../consts';
 
 interface Props {
 	title: string;
@@ -68,7 +68,7 @@ const imageUrl = new URL(image.src, siteOrigin).toString();
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content="@guihubie" />
+<meta name="twitter:site" content={HANDLE} />
 <meta property="twitter:url" content={absoluteUrl} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />

--- a/src/components/sections/Header.astro
+++ b/src/components/sections/Header.astro
@@ -1,5 +1,5 @@
 ---
-import { SITE_TITLE } from '../../consts';
+import { SITE_TITLE, TWITTER, LINKEDIN } from '../../consts';
 import HeaderLink from './HeaderLink.astro';
 import ThemeToggle from '../ui/button/ThemeToggle.astro';
 ---
@@ -20,7 +20,7 @@ import ThemeToggle from '../ui/button/ThemeToggle.astro';
         </div>
         <div class="flex items-center gap-3">
             <div class="social-links hidden md:flex items-center gap-3">
-                <a href="https://x.com/guihubie" target="_blank" class="group text-[color:var(--color-text-secondary)]">
+                <a href={TWITTER} target="_blank" class="group text-[color:var(--color-text-secondary)]">
                     <span class="sr-only">Follow on Twitter</span>
                     <!-- X icon -->
                     <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" class="transition-colors group-hover:text-[color:var(--accent)]"><path fill="currentColor" d="M18.146 3H21l-7.5 8.574L22.5 21h-6.297l-4.93-5.597L5.5 21H3l8.106-9.266L3 3h6.453l4.466 5.07L18.146 3Zm-1.103 16.2h1.705L7.05 4.64H5.272l11.771 14.56Z"/></svg>
@@ -46,7 +46,7 @@ import ThemeToggle from '../ui/button/ThemeToggle.astro';
                 <a href="#contact" class="px-2 py-3">Contact</a>
             </div>
             <div class="flex items-center gap-4 pt-2">
-                <a href="https://x.com/guihubie" target="_blank" class="group inline-flex items-center text-[color:var(--color-text-secondary)]">
+                <a href={TWITTER} target="_blank" class="group inline-flex items-center text-[color:var(--color-text-secondary)]">
                     <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true" class="transition-colors group-hover:text-white"><path fill="currentColor" d="M18.146 3H21l-7.5 8.574L22.5 21h-6.297l-4.93-5.597L5.5 21H3l8.106-9.266L3 3h6.453l4.466 5.07L18.146 3Zm-1.103 16.2h1.705L7.05 4.64H5.272l11.771 14.56Z"/></svg>
                 </a>
                 <a href="https://github.com/guihubie/free-astro-template" target="_blank" class="group inline-flex items-center text-[color:var(--color-text-secondary)]">

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,3 +3,8 @@
 
 export const SITE_TITLE = 'Site Author – Personal Blog & Portfolio';
 export const SITE_DESCRIPTION = 'Growth engineering, analytics, and product marketing notes. Case studies, experiments, and projects by Site Author.';
+export const AUTHOR = 'SITE_AUTHOR'
+export const TWITTER = 'https://x.com'
+export const LINKEDIN = 'https://linkedin.com'
+export const HANDLE = '@handle'
+export const SITE_URL = "Example.com"

--- a/src/data/author.ts
+++ b/src/data/author.ts
@@ -1,7 +1,8 @@
 import avatar from '../assets/images/sample-avatar.jpg';
+import {AUTHOR} from '../consts.ts';
 
 export const author = {
-  name: 'Site Author',
+  name: AUTHOR,
   avatar,
   url: '#',
 };

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -8,6 +8,7 @@ import Header from '../components/sections/Header.astro';
 import PostMeta from '../components/ui/meta/PostMeta.astro';
 import ShareButtons from '../components/ui/share/ShareButtons.astro';
 import PostNav from '../components/ui/nav/PostNav.astro';
+import {SITE_TITLE, AUTHOR, SITE_URL} from '../consts.ts';
 
 type BlogData = CollectionEntry<'blog'>['data'];
 type Props = BlogData & { showHeader?: boolean; prevPost?: { id: string; title: string } | null; nextPost?: { id: string; title: string } | null; readingTimeMin?: number };
@@ -22,7 +23,7 @@ const { title, description, pubDate, updatedDate, heroImage, showHeader = true, 
 		<!-- Article specific OG meta -->
 		{pubDate && <meta property="article:published_time" content={new Date(pubDate).toISOString()} />}
 		{updatedDate && <meta property="article:modified_time" content={new Date(updatedDate).toISOString()} />}
-		<meta property="article:author" content={Astro.props.author || 'Site Author'} />
+		<meta property="article:author" content={Astro.props.author || AUTHOR} />
 		{Array.isArray(Astro.props.tags) && Astro.props.tags.map((t) => (
 		  <meta property="article:tag" content={t} />
 		))}
@@ -36,8 +37,8 @@ const { title, description, pubDate, updatedDate, heroImage, showHeader = true, 
 		  image: Astro.props.heroImage ? new URL(Astro.props.heroImage.src, Astro.site).toString() : undefined,
 		  datePublished: pubDate ? new Date(pubDate).toISOString() : undefined,
 		  dateModified: updatedDate ? new Date(updatedDate).toISOString() : undefined,
-		  author: [{ '@type': 'Person', name: Astro.props.author || 'Site Author' }],
-		  publisher: { '@type': 'Organization', name: 'guihubie.com' },
+		  author: [{ '@type': 'Person', name: Astro.props.author || AUTHOR }],
+		  publisher: { '@type': 'Organization', name: SITE_URL },
 		  mainEntityOfPage: new URL(Astro.url.pathname, Astro.site).toString(),
 		  url: new URL(Astro.url.pathname, Astro.site).toString(),
 		})} />
@@ -123,7 +124,7 @@ const { title, description, pubDate, updatedDate, heroImage, showHeader = true, 
                         </div>
                     )}
                     <ShareButtons title={title} url={Astro.url.toString()} />
-					<PostMeta pubDate={pubDate} readingTimeMin={readingTimeMin} authorName={Astro.props.author || 'Site Author'} />
+					<PostMeta pubDate={pubDate} readingTimeMin={readingTimeMin} authorName={Astro.props.author || AUTHOR} />
                     <slot />
                     <PostNav prev={prevPost} next={nextPost} />
                 </div>

--- a/src/pages/blog/author/[slug].astro
+++ b/src/pages/blog/author/[slug].astro
@@ -5,20 +5,21 @@ import Header from '../../../components/sections/Header.astro';
 import Footer from '../../../components/sections/Footer.astro';
 import PostCard from '../../../components/ui/card/PostCard.astro';
 import { slugifyTag as slugify } from '../../../lib/slug';
+import {AUTHOR} from '../../../consts.ts';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
   const authorSlugs = [
     ...new Set(
-      posts.map((p) => slugify(p.data.author || 'Site Author'))
+      posts.map((p) => slugify(p.data.author || AUTHOR))
     ),
   ];
   return authorSlugs.map((slug) => ({ params: { slug } }));
 }
 
 const { slug } = Astro.params;
-const posts = (await getCollection('blog')).filter((p) => slugify(p.data.author || 'Site Author') === slug);
-const authorName = posts[0]?.data.author || 'Site Author';
+const posts = (await getCollection('blog')).filter((p) => slugify(p.data.author || AUTHOR) === slug);
+const authorName = posts[0]?.data.author || AUTHOR;
 ---
 <html lang="en" data-theme="dark" class="dark">
   <head>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/sections/Footer.astro';
 import Header from '../components/sections/Header.astro';
-import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
+import { SITE_DESCRIPTION, SITE_TITLE, TWITTER, LINKEDIN, AUTHOR } from '../consts';
 import HeroSection from '../components/sections/HeroSection.astro';
 import SkillsSection from '../components/sections/SkillsSection.astro';
 import { skills } from '../data/skills';
@@ -33,12 +33,12 @@ import figmaLogo from '../assets/logos/Figma-logo.svg';
     <script type="application/ld+json" set:html={JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'Organization',
-      name: 'Site Author',
+      name: {AUTHOR},
       url: new URL('/', Astro.site).toString(),
       logo: new URL('/favicon.svg', Astro.site).toString(),
       sameAs: [
-        'https://x.com/guihubie',
-        'https://www.linkedin.com/in/guilherme-hubie/',
+        {TWITTER},
+        {LINKEDIN},
       ],
     })} />
 	</head>


### PR DESCRIPTION
I noticed all the social links were duplicated across files. The twitter link is in more than one place, the linkedin is in more than one place, and somewhat the same for Site Author too.

I created constants for these and swapped them in across the various files to make it quicker for someone to just update these across the template.

I have them set to generic "example.com" type addresses in this PR, but can totally set them back to the guihubie defaults.

I didn't touch the top right github link in the header, I do think that's one someone would change manually if they were using the template.

This is also my first pull-request ever, so hopefully I've got this right.